### PR TITLE
Use outputs instead of env

### DIFF
--- a/.github/workflows/build-alpine-apache.yml
+++ b/.github/workflows/build-alpine-apache.yml
@@ -30,9 +30,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Set up tags
+        id: tags
         run: |
-          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_ENV
-          echo "VERSION_TAG=${IMAGE_BASE}:${{ inputs.apache_version }}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=${IMAGE_BASE}:${{ inputs.apache_version }}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -44,8 +45,8 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch' && inputs.do_publish == true
              || github.ref == 'refs/heads/main' }}
           tags: |
-            ${{ env.LATEST_TAG }}-amd64
-            ${{ env.VERSION_TAG }}-amd64
+            ${{ steps.tags.outputs.LATEST_TAG }}-amd64
+            ${{ steps.tags.outputs.VERSION_TAG }}-amd64
           cache-from: type=gha,scope=amd64
           cache-to: type=gha,mode=max,scope=amd64
 
@@ -62,9 +63,10 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Set up tags
+        id: tags
         run: |
-          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_ENV
-          echo "VERSION_TAG=${IMAGE_BASE}:${{ inputs.apache_version }}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=${IMAGE_BASE}:${{ inputs.apache_version }}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -76,8 +78,8 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch' && inputs.do_publish == true
              || github.ref == 'refs/heads/main' }}
           tags: |
-            ${{ env.LATEST_TAG }}-arm64
-            ${{ env.VERSION_TAG }}-arm64
+            ${{ steps.tags.outputs.LATEST_TAG }}-arm64
+            ${{ steps.tags.outputs.VERSION_TAG }}-arm64
           cache-from: type=gha,scope=arm64
           cache-to: type=gha,mode=max,scope=arm64
 
@@ -93,22 +95,33 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Set up tags
+        id: tags
         run: |
-          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_ENV
-          echo "VERSION_TAG=${IMAGE_BASE}:${{ inputs.apache_version }}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=${IMAGE_BASE}:${{ inputs.apache_version }}" >> $GITHUB_OUTPUT
 
-      - name: Create manifests and push
+      - name: Get arm64 digest
+        id: arm64-digest
         run: |
-          arm64sha=$(docker manifest inspect ${{ env.LATEST_TAG }}-arm64 \
-            | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
-          amd64sha=$(docker manifest inspect ${{ env.LATEST_TAG }}-amd64 \
-            | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
-          docker manifest create ${{ env.LATEST_TAG }} \
-            ${{ env.IMAGE_BASE }}@$arm64sha \
-            ${{ env.IMAGE_BASE }}@$amd64sha
-          docker manifest push -p ${{ env.LATEST_TAG }}
-          docker manifest create ${{ env.VERSION_TAG }} \
-            ${{ env.IMAGE_BASE }}@$arm64sha \
-            ${{ env.IMAGE_BASE }}@$amd64sha
-          docker manifest push -p ${{ env.VERSION_TAG }}
+          digest=$(docker manifest inspect ${{ steps.tags.outputs.LATEST_TAG }}-arm64 | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
 
+      - name: Get amd64 digest
+        id: amd64-digest
+        run: |
+          digest=$(docker manifest inspect ${{ steps.tags.outputs.LATEST_TAG }}-amd64 | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+
+      - name: Create and push latest manifest
+        run: |
+          docker manifest create ${{ steps.tags.outputs.LATEST_TAG }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.arm64-digest.outputs.digest }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.amd64-digest.outputs.digest }}
+          docker manifest push -p ${{ steps.tags.outputs.LATEST_TAG }}
+
+      - name: Create and push version manifest
+        run: |
+          docker manifest create ${{ steps.tags.outputs.VERSION_TAG }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.arm64-digest.outputs.digest }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.amd64-digest.outputs.digest }}
+          docker manifest push -p ${{ steps.tags.outputs.VERSION_TAG }}

--- a/.github/workflows/build-alpine-fips.yml
+++ b/.github/workflows/build-alpine-fips.yml
@@ -40,9 +40,10 @@ jobs:
           buildkitd-flags: --debug
 
       - name: Set up tags
+        id: tags
         run: |
-          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_ENV
-          echo "VERSION_TAG=${IMAGE_BASE}:${BASE_VERSION}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${{ env.IMAGE_BASE }}:latest" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=${{ env.IMAGE_BASE }}:${{ env.BASE_VERSION }}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -54,12 +55,12 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch' && inputs.do_publish == true
              || github.ref == 'refs/heads/main' }}
           tags: |
-            ${{ env.LATEST_TAG }}-amd64
-            ${{ env.VERSION_TAG }}-amd64
+            ${{ steps.tags.outputs.LATEST_TAG }}-amd64
+            ${{ steps.tags.outputs.VERSION_TAG }}-amd64
           # Improved cache configuration
           cache-from: |
             type=gha,scope=alpine-fips-amd64-${{ env.BASE_VERSION }}
-            type=registry,ref=${{ env.LATEST_TAG }}-amd64
+            type=registry,ref=${{ steps.tags.outputs.LATEST_TAG }}-amd64
           cache-to: |
             type=gha,mode=max,scope=alpine-fips-amd64-${{ env.BASE_VERSION }},ignore-error=true
 
@@ -81,9 +82,10 @@ jobs:
           buildkitd-flags: --debug
 
       - name: Set up tags
+        id: tags
         run: |
-          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_ENV
-          echo "VERSION_TAG=${IMAGE_BASE}:${BASE_VERSION}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${{ env.IMAGE_BASE }}:latest" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=${{ env.IMAGE_BASE }}:${{ env.BASE_VERSION }}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -95,12 +97,12 @@ jobs:
             ${{ github.event_name == 'workflow_dispatch' && inputs.do_publish == true
              || github.ref == 'refs/heads/main' }}
           tags: |
-            ${{ env.LATEST_TAG }}-arm64
-            ${{ env.VERSION_TAG }}-arm64
+            ${{ steps.tags.outputs.LATEST_TAG }}-arm64
+            ${{ steps.tags.outputs.VERSION_TAG }}-arm64
           # Improved cache configuration
           cache-from: |
             type=gha,scope=alpine-fips-arm64-${{ env.BASE_VERSION }}
-            type=registry,ref=${{ env.LATEST_TAG }}-arm64
+            type=registry,ref=${{ steps.tags.outputs.LATEST_TAG }}-arm64
           cache-to: |
             type=gha,mode=max,scope=alpine-fips-arm64-${{ env.BASE_VERSION }},ignore-error=true
 
@@ -116,22 +118,33 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Set up tags
+        id: tags
         run: |
-          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_ENV
-          echo "VERSION_TAG=${IMAGE_BASE}:${BASE_VERSION}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${{ env.IMAGE_BASE }}:latest" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=${{ env.IMAGE_BASE }}:${{ env.BASE_VERSION }}" >> $GITHUB_OUTPUT
 
-      - name: Create manifests and push
+      - name: Get arm64 digest
+        id: arm64-digest
         run: |
-          arm64sha=$(docker manifest inspect ${{ env.LATEST_TAG }}-arm64 \
-            | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
-          amd64sha=$(docker manifest inspect ${{ env.LATEST_TAG }}-amd64 \
-            | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
-          docker manifest create ${{ env.LATEST_TAG }} \
-            ${{ env.IMAGE_BASE }}@$arm64sha \
-            ${{ env.IMAGE_BASE }}@$amd64sha
-          docker manifest push -p ${{ env.LATEST_TAG }}
-          docker manifest create ${{ env.VERSION_TAG }} \
-            ${{ env.IMAGE_BASE }}@$arm64sha \
-            ${{ env.IMAGE_BASE }}@$amd64sha
-          docker manifest push -p ${{ env.VERSION_TAG }}
+          digest=$(docker manifest inspect ${{ steps.tags.outputs.LATEST_TAG }}-arm64 | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
 
+      - name: Get amd64 digest
+        id: amd64-digest
+        run: |
+          digest=$(docker manifest inspect ${{ steps.tags.outputs.LATEST_TAG }}-amd64 | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+
+      - name: Create and push latest manifest
+        run: |
+          docker manifest create ${{ steps.tags.outputs.LATEST_TAG }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.arm64-digest.outputs.digest }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.amd64-digest.outputs.digest }}
+          docker manifest push -p ${{ steps.tags.outputs.LATEST_TAG }}
+
+      - name: Create and push version manifest
+        run: |
+          docker manifest create ${{ steps.tags.outputs.VERSION_TAG }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.arm64-digest.outputs.digest }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.amd64-digest.outputs.digest }}
+          docker manifest push -p ${{ steps.tags.outputs.VERSION_TAG }}

--- a/.github/workflows/build-alpine-tomcat.yml
+++ b/.github/workflows/build-alpine-tomcat.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Compose tag names
+      - name: Set up tags
+        id: tags
         run: |
-          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_ENV
-          echo "VERSION_TAG=${IMAGE_BASE}:${{ inputs.tomcat_version }}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${{ env.IMAGE_BASE }}:latest" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=${{ env.IMAGE_BASE }}:${{ inputs.tomcat_version }}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -49,8 +50,8 @@ jobs:
           build-args: |
             TOMCAT_VERSION=${{ inputs.tomcat_version }}
           tags: |
-            ${{ env.LATEST_TAG }}-amd64
-            ${{ env.VERSION_TAG }}-amd64
+            ${{ steps.tags.outputs.LATEST_TAG }}-amd64
+            ${{ steps.tags.outputs.VERSION_TAG }}-amd64
 
   build-push-arm64:
     runs-on: ubuntu-24.04-arm
@@ -69,10 +70,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Compose tag names
+      - name: Set up tags
+        id: tags
         run: |
-          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_ENV
-          echo "VERSION_TAG=${IMAGE_BASE}:${{ inputs.tomcat_version }}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${{ env.IMAGE_BASE }}:latest" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=${{ env.IMAGE_BASE }}:${{ inputs.tomcat_version }}" >> $GITHUB_OUTPUT
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -82,8 +84,8 @@ jobs:
           build-args: |
             TOMCAT_VERSION=${{ inputs.tomcat_version }}
           tags: |
-            ${{ env.LATEST_TAG }}-arm64
-            ${{ env.VERSION_TAG }}-arm64
+            ${{ steps.tags.outputs.LATEST_TAG }}-arm64
+            ${{ steps.tags.outputs.VERSION_TAG }}-arm64
 
   create-push-manifests:
     if: github.ref == 'refs/heads/main'
@@ -99,23 +101,35 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Compose tag names
+      - name: Set up tags
+        id: tags
         run: |
-          echo "LATEST_TAG=${IMAGE_BASE}:latest" >> $GITHUB_ENV
-          echo "VERSION_TAG=${IMAGE_BASE}:${{ inputs.tomcat_version }}" >> $GITHUB_ENV
+          echo "LATEST_TAG=${{ env.IMAGE_BASE }}:latest" >> $GITHUB_OUTPUT
+          echo "VERSION_TAG=${{ env.IMAGE_BASE }}:${{ inputs.tomcat_version }}" >> $GITHUB_OUTPUT
 
-      - name: Create manifests and push
+      - name: Get arm64 digest
+        id: arm64-digest
         run: |
-          arm64sha=$(docker manifest inspect ${{ env.LATEST_TAG }}-arm64 \
-            | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
-          amd64sha=$(docker manifest inspect ${{ env.LATEST_TAG }}-amd64 \
-            | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
-          docker manifest create ${{ env.LATEST_TAG }} \
-            ${{ env.IMAGE_BASE }}@$arm64sha \
-            ${{ env.IMAGE_BASE }}@$amd64sha
-          docker manifest push -p ${{ env.LATEST_TAG }}
-          docker manifest create ${{ env.VERSION_TAG }} \
-            ${{ env.IMAGE_BASE }}@$arm64sha \
-            ${{ env.IMAGE_BASE }}@$amd64sha
-          docker manifest push -p ${{ env.VERSION_TAG }}
+          digest=$(docker manifest inspect ${{ steps.tags.outputs.LATEST_TAG }}-arm64 | jq -r '.manifests[] | select(.platform.architecture == "arm64") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+
+      - name: Get amd64 digest
+        id: amd64-digest
+        run: |
+          digest=$(docker manifest inspect ${{ steps.tags.outputs.LATEST_TAG }}-amd64 | jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest')
+          echo "digest=$digest" >> $GITHUB_OUTPUT
+
+      - name: Create and push latest manifest
+        run: |
+          docker manifest create ${{ steps.tags.outputs.LATEST_TAG }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.arm64-digest.outputs.digest }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.amd64-digest.outputs.digest }}
+          docker manifest push -p ${{ steps.tags.outputs.LATEST_TAG }}
+
+      - name: Create and push version manifest
+        run: |
+          docker manifest create ${{ steps.tags.outputs.VERSION_TAG }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.arm64-digest.outputs.digest }} \
+            ${{ env.IMAGE_BASE }}@${{ steps.amd64-digest.outputs.digest }}
+          docker manifest push -p ${{ steps.tags.outputs.VERSION_TAG }}
 

--- a/.github/workflows/check-tomcat-version.yaml
+++ b/.github/workflows/check-tomcat-version.yaml
@@ -34,14 +34,14 @@ jobs:
           restore-keys: |
             tomcat-version-${{ runner.os }}-
 
-      # Set previous version environment variable
+      # Set previous version as step output
       - name: Set previous version
         id: previous
         run: |
           if [ -f "previous_version.txt" ]; then
-            echo "previous_version=$(cat previous_version.txt)" >> $GITHUB_ENV
+            echo "version=$(cat previous_version.txt)" >> $GITHUB_OUTPUT
           else
-            echo "previous_version=none" >> $GITHUB_ENV
+            echo "version=none" >> $GITHUB_OUTPUT
           fi
 
       # Scrape the latest Tomcat version using curl and grep/sed
@@ -59,8 +59,10 @@ jobs:
       - name: Compare versions
         id: compare
         run: |
-          # Read the new version from file
-          new_version=$(cat version.txt)
+          # Use the outputs from previous steps
+          new_version="${{ steps.scrape.outputs.new_version }}"
+          previous_version="${{ steps.previous.outputs.version }}"
+          
           if [ "$new_version" == "unknown" ]; then
             echo "Could not determine available version of Tomcat."
             exit 1
@@ -75,7 +77,7 @@ jobs:
 
       # Save new version to cache
       - name: Save new version to cache
-        if: steps.scrape.outputs.new_version != 'unknown' && steps.scrape.outputs.new_version != env.previous_version
+        if: steps.scrape.outputs.new_version != 'unknown' && steps.scrape.outputs.new_version != steps.previous.outputs.version
         run: |
           mv version.txt previous_version.txt
           # Cache will be updated automatically by actions/cache
@@ -83,8 +85,8 @@ jobs:
   # Trigger build-alpine-tomcat workflow
   call-build-alpine-tomcat:
     needs: check-version # Run after check-version job
-    if: needs.check-version.new_version_detected == 'true' # Only run if new version detected
+    if: needs.check-version.outputs.new_version_detected == 'true' # Only run if new version detected
     uses: ./.github/workflows/build-alpine-tomcat.yml
     with:
-      tomcat_version: ${{ needs.check-version.new_version }}
+      tomcat_version: ${{ needs.check-version.outputs.new_version }}
     secrets: inherit # Pass all secrets from the calling workflow


### PR DESCRIPTION
* uses step outputs for tags instead of env variables. cleans up linting.